### PR TITLE
fixed php code sample

### DIFF
--- a/xml/index.html
+++ b/xml/index.html
@@ -126,9 +126,7 @@ interface is designed to work identical to PHP 5.5's <a href="http://php.net/man
 
 <h2 id="reading-xml">Reading XML</h2>
 
-<pre><code>&lt;?php
-
-$input = &lt;&lt;&lt;XML
+<pre><code>$input = &lt;&lt;&lt;XML
 &lt;article xmlns="http://example.org/"&gt;
     &lt;title&gt;Hello world&lt;/title&gt;
     &lt;content&gt;Fuzzy Pickles&lt;/content&gt;


### PR DESCRIPTION
the code sample at the page has a opacity of 0.5, which makes it hard to read.
I dont know exactly where it comes from, but I guess the php-starting tag, which is not present in the other php code snippets could be the reason

see the greyed shadow over the "Reading XML" Code box
http://i.imgur.com/GsadATy.png
